### PR TITLE
Make it so that tonatona.hsfile will fetch the latest commit

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,8 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+    - wai-extra-3.0.29.1@sha256:72c29434fe20a0d2bc6f5f292c9c9694c0d106dd2abf755d394d158593524d3f,7046
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,6 +48,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
     - wai-extra-3.0.29.1@sha256:72c29434fe20a0d2bc6f5f292c9c9694c0d106dd2abf755d394d158593524d3f,7046
+    - streaming-commons-0.2.1.2@sha256:7830ce8a437bbe8b6546b03308d86e2f6c96bc1b62c2d0c007c44b27f3849a20,4990
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/tonatona.hsfiles
+++ b/tonatona.hsfiles
@@ -273,7 +273,7 @@ packages:
   - '.'
 extra-deps:
   - git: https://github.com/tonatona-project/tonatona
-    commit: bc916ac3bd633075950ac8976282aa7b5c02da4e
+    commit: 90fa2abcfcc7077c2bb3bdf04a85752aab19725e
     subdirs:
       - tonalude
       - tonaparser


### PR DESCRIPTION
Update `tonatona.hsfiles` so that it pulls the latest commit of `Tonatona`. The current `tonatona.hsfiles` is pulling from [commit](https://github.com/tonatona-project/tonatona/commit/bc916ac3bd633075950ac8976282aa7b5c02da4e) which has some issues when building with latest resolver such as `lts-14.19`

```
 tonatona-servant> /tmp/stack1733/tonatona-servant-0.1.0.0/src/Tonatona/Servant.hs:53:53: error:
 tonatona-servant>     Not in scope: type constructor or class ‘ServantErr’
 tonatona-servant>    |
 tonatona-servant> 53 |       eitherRes <- liftIO $ ioAction `catch` \(e :: ServantErr) -> pure $ Left e
 tonatona-servant>    |                                                     ^^^^^^^^^^
 tonatona-servant>
```

This is due to `tonatona.hsfiles` pulling `Tonatona` template which does not include the [commit](https://github.com/tonatona-project/tonatona/commit/fe9a0728e3912eab000a482f8a62686e08cc891c) which fixes it.